### PR TITLE
Dom tests

### DIFF
--- a/omnipaxos/src/dom/buffer.rs
+++ b/omnipaxos/src/dom/buffer.rs
@@ -140,3 +140,90 @@ pub(crate) enum EarlyBufferInsertError<T: Entry> {
     /// The request was late and could not be inserted.
     Late(DomPropose<T>),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dom::test_utils::*;
+    
+    #[test]
+    fn early_buffer_correct_insert_test() {
+        let mut buffer: EarlyBuffer<TestEntry> = EarlyBuffer::new();
+
+        let propose1 = DomPropose {
+            entry_id: EntryId { client_id: 0, command_id: 0 },
+            sender: 0,
+            sent_time: (10, 5),
+            deadline: 20,
+            entry: TestEntry,
+        };
+
+        let res = buffer.insert(propose1.clone());
+        assert!(res.is_ok(), "First proposal should be accepted");
+
+        let propose2 = DomPropose {
+            entry_id: EntryId { client_id: 1, command_id: 0 },
+            sender: 0,
+            sent_time: (20, 5),
+            deadline: 30,
+            entry: TestEntry,
+        };
+
+        let propose3 = DomPropose {
+            entry_id: EntryId { client_id: 0, command_id: 1 },
+            sender: 0,
+            sent_time: (20, 5),
+            deadline: 30,
+            entry: TestEntry,
+        };
+
+        let res = buffer.insert(propose2.clone());
+        assert!(res.is_ok(), "Second proposal should be accepted");
+        let res = buffer.insert(propose3.clone());
+        assert!(res.is_ok(), "Third proposal should be accepted");
+
+        let not_ready = buffer.pop_ready(10).is_none();
+        assert!(not_ready, "No proposals should be ready yet");
+
+        let first= buffer.pop_ready(20).unwrap();
+        assert!(compare_proposes(first, propose1), "First proposal should be released");
+
+        let second = buffer.pop_ready(40).unwrap();
+        let third = buffer.pop_ready(40).unwrap();
+        assert!(compare_proposes(second, propose3), "Tie-break should order this before the second proposal");
+        assert!(compare_proposes(third, propose2), "Tie-break should order this after the third proposal");
+
+        let empty = buffer.peek();
+        assert!(empty.is_none(), "Early buffer should be empty");
+    }
+
+    #[test]
+    fn early_buffer_reject_late_test() {
+        let mut buffer: EarlyBuffer<TestEntry> = EarlyBuffer::new();
+
+        let first_propose = DomPropose {
+            entry_id: EntryId { client_id: 0, command_id: 0 },
+            sender: 0,
+            sent_time: (10, 5),
+            deadline: 20,
+            entry: TestEntry,
+        };
+
+        let res = buffer.insert(first_propose);
+        assert!(res.is_ok(), "First proposal should be accepted");
+
+        let ready = buffer.pop_ready(25).unwrap();
+        assert_eq!(buffer.last_released.unwrap().deadline, ready.deadline);
+
+        let late_propose = DomPropose {
+            entry_id: EntryId { client_id: 1, command_id: 0 },
+            sender: 1,
+            sent_time: (5, 1),
+            deadline: ready.deadline - 1,
+            entry: TestEntry,
+        };
+
+        let err = buffer.insert(late_propose);
+        assert!(err.is_err(), "Late proposal should not be accepted");
+    }
+}

--- a/omnipaxos/src/dom/mod.rs
+++ b/omnipaxos/src/dom/mod.rs
@@ -10,6 +10,8 @@ use std::cmp::max;
 
 mod buffer;
 mod owd_estimator;
+mod test_utils;
+
 pub(crate) use owd_estimator::{EstimatorStrategy, OwdEstimatorConfig};
 
 const ONE_MICRO_SECOND: i64 = 1000;
@@ -160,5 +162,86 @@ where
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::util::{SystemClock, SYSTEM_CLOCK};
+    use super::*;
+    use crate::dom::test_utils::*;
+
+    #[test]
+    fn handle_dom_propose_test() {
+        let clock = &SYSTEM_CLOCK;
+        let config = OwdEstimatorConfig::new(
+            5,
+            100,
+            10,
+            EstimatorStrategy::Percentile { percentile: 0.5 },
+        ).unwrap();
+        let mut dom: Dom<TestEntry, SystemClock> = Dom::new(config, clock, 0);
+
+        let propose1 = dom.create_dom_propose(
+            TestEntry,
+            EntryId { client_id: 1, command_id: 0 }
+        );
+        let propose2 = dom.create_dom_propose(
+            TestEntry,
+            EntryId { client_id: 0, command_id: 1 }
+        );
+        let mut propose3 = propose1.clone();
+        propose3.deadline = propose1.deadline;
+        propose3.entry_id = EntryId { client_id: 0, command_id: 0 };
+
+        let _ = dom.handle_dom_propose(propose1.clone(), Role::Leader);
+        let _ = dom.handle_dom_propose(propose2.clone(), Role::Leader);
+        let ack = dom.handle_dom_propose(propose3.clone(), Role::Leader);
+
+        // Ensure that the ack contains the correct OWD estimate
+        assert_eq!(ack.estimated_owd, dom.incoming_owd_estimates.estimate_for(propose3.sender),
+                   "ack should contain the correct OWD estimate");
+
+        let ready = dom.release_ready();
+
+        // max_owd is short enough for the deadline to pass
+        // Proposals should be ordered p3 > p1 (reorder + tie-break), p1 > p2 (deadline)
+        assert_eq!(ready.len(), 3, "dom should have released 3 proposals");
+        assert!(compare_proposes(ready[0].clone(), propose3));
+        assert!(compare_proposes(ready[1].clone(), propose1));
+        assert!(compare_proposes(ready[2].clone(), propose2));
+
+        // Ensure follower ignores late proposals
+        let mut late_follower = dom.create_dom_propose(
+            TestEntry,
+            EntryId { client_id: 0, command_id: 2 }
+        );
+        late_follower.deadline = 1;
+        let _ = dom.handle_dom_propose(late_follower.clone(), Role::Follower);
+        let ready = dom.release_ready();
+        assert_eq!(ready.len(), 0, "follower should not add late proposals to the buffer");
+
+        // Verify that leader extends the deadline of late proposals
+        let mut late_leader = dom.create_dom_propose(
+            TestEntry,
+            EntryId { client_id: 0, command_id: 3 }
+        );
+        late_leader.deadline = 1;
+        let ack = dom.handle_dom_propose(late_leader.clone(), Role::Leader);
+        let ready = dom.release_ready();
+        assert_eq!(ready.len(), 1,
+                   "leader should add late proposals to the buffer after extending the deadline");
+        assert_eq!(ready[0].entry_id, late_leader.entry_id);
+        assert!(ready[0].deadline > late_leader.deadline, "deadline should be extended");
+
+        // Verify correct use of OWD estimates when setting deadline
+        let owd_estimate = ack.estimated_owd;
+        dom.handle_dom_ack(ack);
+        let proposal = dom.create_dom_propose(
+            TestEntry,
+            EntryId { client_id: 0, command_id: 4 }
+        );
+        assert_eq!(proposal.deadline, proposal.sent_time.0 + owd_estimate,
+                   "deadline should be extended by OWD estimate");
     }
 }

--- a/omnipaxos/src/dom/owd_estimator.rs
+++ b/omnipaxos/src/dom/owd_estimator.rs
@@ -241,3 +241,61 @@ impl OutgoingOwdTracker {
         self.estimates.clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owd_estimator_test() {
+        let config = OwdEstimatorConfig {
+            window_size: 5,
+            max_owd: 100,
+            uncertainty_beta: 10,
+            strategy: EstimatorStrategy::Percentile { percentile: 0.5 },
+        };
+
+        let mut estimator = OwdEstimator::with_config(config);
+
+        let node = 0;
+
+        assert_eq!(estimator.estimate_for(node), 100, "Initial estimate should be max_owd when there are no samples");
+
+        estimator.update(node, OwdSample::new(10, 30, 5, 5));
+
+        // OWD = D + B(u_s + u_r)=120>100 [D=20, B=10, u_s=5, u_r=5]
+        assert_eq!(estimator.estimate_for(node), 100, "OWD should not exceed max_owd");
+
+        estimator.update(node, OwdSample::new(20, 40, 5, 5));
+        estimator.update(node, OwdSample::new(30, 50, 5, 5));
+        estimator.update(node, OwdSample::new(40, 50, 5, 5));
+
+        // Update uncertainty of last message
+        estimator.update(node, OwdSample::new(50, 70, 2, 2));
+
+        // [D=20, B=10, u_s=2, u_r=2]
+        assert_eq!(estimator.estimate_for(node), 60, "OWD should use uncertainty of last message");
+
+        // Push OWD=20 samples outside percentile range
+        estimator.update(node, OwdSample::new(60, 70, 2, 2));
+        estimator.update(node, OwdSample::new(70, 80, 2, 2));
+        estimator.update(node, OwdSample::new(80, 90, 2, 2));
+
+        assert_eq!(estimator.estimate_for(node), 50, "OWD should use percentile 0.5");
+    }
+
+    #[test]
+    fn owd_tracker_test() {
+        let default_owd = 100;
+        let mut tracker = OutgoingOwdTracker::new(default_owd);
+
+        assert_eq!(tracker.get(0), default_owd, "Tracker should return default estimate for unknown peer");
+
+        tracker.update(0, 20);
+        assert_eq!(tracker.get(0), 20, "Tracker should return updated estimate");
+
+        tracker.update(1, 30);
+
+        assert_eq!(tracker.get_max_owd(), 30, "Tracker should return max estimate across all peers");
+    }
+}

--- a/omnipaxos/src/dom/test_utils.rs
+++ b/omnipaxos/src/dom/test_utils.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+use crate::messages::sequence_paxos::DomPropose;
+use crate::storage::{Entry, Snapshot};
+
+#[derive(Clone, Debug)]
+pub(crate) struct TestEntry;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct TestSnapshot;
+
+impl Snapshot<TestEntry> for TestSnapshot {
+    fn create(_entries: &[TestEntry]) -> Self {
+        TestSnapshot
+    }
+
+    fn merge(&mut self, _delta: Self) {}
+
+    fn use_snapshots() -> bool {
+        false
+    }
+}
+
+impl Entry for TestEntry {
+    type Snapshot = TestSnapshot;
+}
+
+/// Returns true if the two proposals have the same deadline and entry id.
+pub(crate) fn compare_proposes(prop1: DomPropose<TestEntry>, prop2: DomPropose<TestEntry>) -> bool {
+    prop1.deadline == prop2.deadline && prop1.entry_id == prop2.entry_id
+}


### PR DESCRIPTION
Add basic unit tests for the DOM, the OWD estimator and the buffer.

Tests are currently placed in the same file as the code they test, but could be moved to a separate tests submodule in the dom module if we want.